### PR TITLE
Updated  to include Remove-FsrmFileScreenException

### DIFF
--- a/DeployCryptoBlocker.ps1
+++ b/DeployCryptoBlocker.ps1
@@ -328,7 +328,8 @@ if (Test-Path .\ExcludePaths.txt)
 If (Test-Path $PSScriptRoot\ExcludePaths.txt) {
     Get-Content $PSScriptRoot\ExcludePaths.txt | ForEach-Object {
         If (Test-Path $_) {
-            New-FsrmFileScreenException -Path "$_" -IncludeGroup @($fileGroupNames)
+            Remove-FsrmFileScreenException -Path "$_" -Confirm:$false
+	    New-FsrmFileScreenException -Path "$_" -IncludeGroup @($fileGroupNames)
         }
     }
 }


### PR DESCRIPTION
Added a command to remove existing File Screen Exception before creating a new one.  If the contents of the ExcludePaths.txt changes this will correct the creation of the new screen.  For example, if a path was in the ExcludePaths.txt file and then is removed from it; the previous version of the script would not have removed that path from the Exception List and the location would still be excluded despite it no longer being in the ExcludePaths.txt file.  This corrects that oversight.